### PR TITLE
Refactor: Remove Docker-in-Docker for Ebesucher/Adnade restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,59 @@ This will show whether each container is running, exited, or in another state.
 ## :grey_question: FAQ
 ### <ins>[Click here to view Frequently Asked Questions](https://github.com/engageub/InternetIncome/wiki/Frequently-Asked-Questions)</ins> 
 
+### Ebesucher/Adnade Automatic Restart Changes
+
+**Important Note:** The previous mechanism for automatically restarting Ebesucher and Adnade browser instances using Docker-in-Docker (DinD) has been removed from `internetIncome.sh`. This change was made due to compatibility issues and to simplify the script's dependencies.
+
+If you relied on this automatic restart functionality, you will need to set up an alternative method. We recommend using a cron job on your host system to periodically execute the `restart.sh` script with the appropriate arguments.
+
+**What is a cron job?**
+A cron job is a time-based job scheduler in Unix-like computer operating systems. Users can schedule jobs (commands or shell scripts) to run periodically at fixed times, dates, or intervals.
+
+**How to set up a cron job for restarting Ebesucher/Adnade:**
+
+1.  **Open your crontab:**
+    You can edit your user's crontab file by running the following command in your terminal:
+    ```bash
+    crontab -e
+    ```
+    If prompted, choose an editor (like nano).
+
+2.  **Add a cron job entry:**
+    You'll need to add a line to this file for each service you want to restart. The format is:
+    `[minute] [hour] [day_of_month] [month] [day_of_week] [command_to_execute]`
+
+    *   Replace `/path/to/InternetIncome-main` with the actual absolute path to your `InternetIncome-main` directory.
+
+    **Example Cron Job Entries:**
+
+    *   **To restart Adnade every 6 hours:**
+        ```cron
+        0 */6 * * * cd /path/to/InternetIncome-main && sudo bash restart.sh --restartAdnade >> /path/to/InternetIncome-main/adnade_restart.log 2>&1
+        ```
+
+    *   **To restart Ebesucher (Firefox) once a day at 3:00 AM:**
+        ```cron
+        0 3 * * * cd /path/to/InternetIncome-main && sudo bash restart.sh --restartFirefox >> /path/to/InternetIncome-main/ebesucher_firefox_restart.log 2>&1
+        ```
+
+    *   **To restart Ebesucher (Chrome) every 12 hours:**
+        ```cron
+        0 */12 * * * cd /path/to/InternetIncome-main && sudo bash restart.sh --restartChrome >> /path/to/InternetIncome-main/ebesucher_chrome_restart.log 2>&1
+        ```
+
+    **Explanation of the cron job:**
+    *   `0 */6 * * *`: This means "at minute 0 of every 6th hour."
+    *   `0 3 * * *`: This means "at 03:00 (3 AM) every day."
+    *   `cd /path/to/InternetIncome-main`: This changes the directory to where your `internetIncome.sh` and `restart.sh` scripts are located. **It is crucial to use the correct absolute path.**
+    *   `sudo bash restart.sh --restartAdnade`: This is the command that executes the restart.
+    *   `>> /path/to/InternetIncome-main/adnade_restart.log 2>&1`: This is optional but recommended. It redirects the output (both standard output and errors) of the command to a log file, so you can check if the restarts are happening correctly. Make sure the log path is writable.
+
+3.  **Save and exit:**
+    If you used nano, press `Ctrl+X`, then `Y`, then `Enter`.
+
+This manual setup gives you more control over the restart schedule and avoids the complexities of DinD. Remember to adjust the cron schedule and paths to fit your specific needs.
+
 ## 💖 Support the Project
 This script is provided free of charge and is maintained by the author in their free time. If you find this script useful and would like to support its continued development and maintenance, please consider the following options:
 

--- a/internetIncome.sh
+++ b/internetIncome.sh
@@ -336,14 +336,6 @@ start_containers() {
         exit 1
       fi
 
-      if CONTAINER_ID=$(sudo docker run -d --name dind$UNIQUE_ID$i $LOGS_PARAM -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/chrome docker:20.10.24-cli-alpine3.18 /bin/sh -c 'apk add --no-cache bash && cd /chrome && chmod +x /chrome/restart.sh && while true; do sleep 3600; /chrome/restart.sh --restartChrome; done'); then
-        echo "Chrome restart container started"
-        echo "$CONTAINER_ID" | tee -a $containers_file
-        echo "dind$UNIQUE_ID$i" | tee -a $container_names_file
-      else
-        echo -e "${RED}Failed to start container for ebesucher chrome restart. Exiting..${NOCOLOUR}"
-        exit 1
-      fi
     fi
 
     # Create folder and copy files
@@ -401,14 +393,6 @@ start_containers() {
         exit 1
       fi
 
-      if CONTAINER_ID=$(sudo docker run -d --name dind$UNIQUE_ID$i $LOGS_PARAM --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/firefox docker:20.10.24-cli-alpine3.18 /bin/sh -c 'apk add --no-cache bash && cd /firefox && chmod +x /firefox/restart.sh && while true; do sleep 3600; /firefox/restart.sh --restartFirefox; done'); then
-        echo "Firefox restart container started"
-        echo "$CONTAINER_ID" | tee -a $containers_file
-        echo "dind$UNIQUE_ID$i" | tee -a $container_names_file
-      else
-        echo -e "${RED}Failed to start container for ebesucher firefox restart. Exiting..${NOCOLOUR}"
-        exit 1
-      fi
     fi
 
     # Create folder and copy files
@@ -464,14 +448,6 @@ start_containers() {
         exit 1
       fi
 
-      if CONTAINER_ID=$(sudo docker run -d --name adnadedind$UNIQUE_ID$i $LOGS_PARAM --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/firefox docker:20.10.24-cli-alpine3.18 /bin/sh -c 'apk add --no-cache bash && cd /firefox && chmod +x /firefox/restart.sh && while true; do sleep 7200; /firefox/restart.sh --restartAdnade; done'); then
-        echo "Firefox restart container started"
-        echo "$CONTAINER_ID" | tee -a $containers_file
-        echo "adnadedind$UNIQUE_ID$i" | tee -a $container_names_file
-      else
-        echo -e "${RED}Failed to start container for adnade firefox restart. Exiting..${NOCOLOUR}"
-        exit 1
-      fi
     fi
 
     # Create folder and copy files

--- a/restart.sh
+++ b/restart.sh
@@ -10,27 +10,27 @@ if [[ "$1" == "--restartAdnade" ]]; then
     docker update --restart=no $container
     docker stop $container
     # Firefox with direct connection
-    if [ -d "/firefox/adnadedata/data" ];then
-      chmod -R 777 /firefox/adnadedata/data
-      rm -rf /firefox/adnadedata/data/*
-      cp -r /firefox/$firefox_profile_data/* adnadedata/data/
-      chmod -R 777 /firefox/adnadedata/data
+    if [ -d "adnadedata/data" ];then
+      chmod -R 777 adnadedata/data
+      rm -rf adnadedata/data/*
+      cp -r $firefox_profile_data/* adnadedata/data/
+      chmod -R 777 adnadedata/data
       docker update --restart=always $container
       sleep 300
       docker start $container
       exit 1
     fi
 
-    if [ ! -d "/firefox/adnadedata/data$i" ];then
+    if [ ! -d "adnadedata/data$i" ];then
       echo "Folder data$i does not exist. Exiting.."
       exit 1
     fi
 
     # Deleting data and starting containers
-    chmod -R 777 /firefox/adnadedata/data$i
-    rm -rf /firefox/adnadedata/data$i/*
-    cp -r /firefox/$firefox_profile_data/* adnadedata/data$i/
-    chmod -R 777 /firefox/adnadedata/data$i
+    chmod -R 777 adnadedata/data$i
+    rm -rf adnadedata/data$i/*
+    cp -r $firefox_profile_data/* adnadedata/data$i/
+    chmod -R 777 adnadedata/data$i
     docker update --restart=always $container
     if [ $i == 1 ];then
       sleep 300
@@ -49,28 +49,28 @@ elif [[ "$1" == "--restartChrome" ]]; then
     docker update --restart=no $container
     docker stop $container
     # Chrome with direct connection
-    if [ -d "/chrome/$chrome_data_folder/data" ];then
-      chmod -R 777 /chrome/$chrome_data_folder/data
-      rm -rf /chrome/$chrome_data_folder/data/*
-      chown -R 911:911 /chrome/$chrome_profile_data
-      cp -r /chrome/$chrome_profile_data /chrome/$chrome_data_folder/data
-      chown -R 911:911 /chrome/$chrome_data_folder/data
+    if [ -d "$chrome_data_folder/data" ];then
+      chmod -R 777 $chrome_data_folder/data
+      rm -rf $chrome_data_folder/data/*
+      chown -R 911:911 $chrome_profile_data
+      cp -r $chrome_profile_data $chrome_data_folder/data
+      chown -R 911:911 $chrome_data_folder/data
       docker update --restart=always $container
       docker start $container
       exit 1
     fi
 
-    if [ ! -d "/chrome/$chrome_data_folder/data$i" ];then
+    if [ ! -d "$chrome_data_folder/data$i" ];then
       echo "Folder data$i does not exist. Exiting.."
       exit 1
     fi
 
     # Deleting data and starting containers
-    chmod -R 777 /chrome/$chrome_data_folder/data$i
-    rm -rf /chrome/$chrome_data_folder/data$i/*
-    chown -R 911:911 /chrome/$chrome_profile_data
-    cp -r /chrome/$chrome_profile_data /chrome/$chrome_data_folder/data$i
-    chown -R 911:911 /chrome/$chrome_data_folder/data$i
+    chmod -R 777 $chrome_data_folder/data$i
+    rm -rf $chrome_data_folder/data$i/*
+    chown -R 911:911 $chrome_profile_data
+    cp -r $chrome_profile_data $chrome_data_folder/data$i
+    chown -R 911:911 $chrome_data_folder/data$i
     docker update --restart=always $container
     docker start $container
   done
@@ -85,26 +85,26 @@ elif [[ "$1" == "--restartFirefox" ]]; then
     docker update --restart=no $container
     docker stop $container
     # Firefox with direct connection
-    if [ -d "/firefox/firefoxdata/data" ];then
-      chmod -R 777 /firefox/firefoxdata/data
-      rm -rf /firefox/firefoxdata/data/*
-      cp -r /firefox/$firefox_profile_data/* firefoxdata/data/
-      chmod -R 777 /firefox/firefoxdata/data
+    if [ -d "firefoxdata/data" ];then
+      chmod -R 777 firefoxdata/data
+      rm -rf firefoxdata/data/*
+      cp -r $firefox_profile_data/* firefoxdata/data/
+      chmod -R 777 firefoxdata/data
       docker update --restart=always $container
       docker start $container
       exit 1
     fi
 
-    if [ ! -d "/firefox/firefoxdata/data$i" ];then
+    if [ ! -d "firefoxdata/data$i" ];then
       echo "Folder data$i does not exist. Exiting.."
       exit 1
     fi
 
     # Deleting data and starting containers
-    chmod -R 777 /firefox/firefoxdata/data$i
-    rm -rf /firefox/firefoxdata/data$i/*
-    cp -r /firefox/$firefox_profile_data/* firefoxdata/data$i/
-    chmod -R 777 /firefox/firefoxdata/data$i
+    chmod -R 777 firefoxdata/data$i
+    rm -rf firefoxdata/data$i/*
+    cp -r $firefox_profile_data/* firefoxdata/data$i/
+    chmod -R 777 firefoxdata/data$i
     docker update --restart=always $container
     docker start $container
   done


### PR DESCRIPTION
I've removed the Docker-in-Docker (DinD) mechanism previously used for automatically restarting the Ebesucher and Adnade browser containers. This change addresses reported compatibility issues where these services may no longer support DinD setups.

Key changes:
- Modified `internetIncome.sh`: Removed the startup of auxiliary 'dind' containers that were responsible for executing `restart.sh`.
- Modified `restart.sh`: Updated paths to be relative to the script's execution directory (the `InternetIncome-main` project root). Paths previously like `/firefox/...` or `/chrome/...` are now relative (e.g., `adnadedata/...`). This allows `restart.sh` to be run directly from the host.
- Updated `README.md`:
    - Added an FAQ section explaining the removal of the DinD restart mechanism for Ebesucher and Adnade.
    - Provided instructions and examples for you to set up your own periodic restarts using cron jobs on the host system if this functionality is still desired.

If you relied on the automatic restart for Ebesucher and Adnade, you will need to configure a cron job (or a similar scheduler) on your host machine to execute `restart.sh` with the appropriate arguments (e.g., `--restartAdnade`, `--restartFirefox`, `--restartChrome`) to maintain periodic restarts.